### PR TITLE
Rewrite using winnow and fixed `parse_tar`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["filesystem", "parser-implementations"]
 license = "MIT"
 
 [dependencies]
-nom = "7"
+winnow = { version = "0.5", features = ["simd"] }
 
 [dev-dependencies]
 tar = "0.4"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,8 @@
 use tar_parser2::*;
 
-fn test_parse_tar(i: &[u8]) {
-    match parse_tar(i) {
-        Ok((_, entries)) => {
+fn test_parse_tar(mut i: &[u8]) {
+    match parse_tar(&mut i) {
+        Ok(entries) => {
             for e in entries.iter() {
                 println!("{e:?}");
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,102 @@
+use std::{borrow::Cow, cmp, error, fmt};
+
+use winnow::error::{AddContext, ErrMode, ErrorKind, FromExternalError, ParserError};
+
+/// Accumulate context while backtracking errors
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    context: Vec<Cow<'static, str>>,
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+impl cmp::Eq for Error {}
+
+impl cmp::PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+            && self.context == other.context
+            && self.source.as_deref().map(|b| b as *const _)
+                == other.source.as_deref().map(|b| b as *const _)
+    }
+}
+
+impl Error {
+    pub(super) fn new(context: impl Into<Cow<'static, str>>) -> ErrMode<Self> {
+        ErrMode::Backtrack(Self {
+            kind: ErrorKind::Fail,
+            context: vec![context.into()],
+            source: None,
+        })
+    }
+
+    /// Access context from [`Parser::context`]
+    pub fn context(&self) -> impl Iterator<Item = &Cow<'static, str>> {
+        self.context.iter()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Error kind: {}", self.kind)?;
+
+        for context in &self.context {
+            write!(f, ", context: {context}")?;
+        }
+
+        if let Some(source) = self.source.as_deref() {
+            f.write_str(", source: ")?;
+            // tailcall
+            fmt::Display::fmt(source, f)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|e| e as &(dyn error::Error + 'static))
+    }
+}
+
+impl<I> ParserError<I> for Error {
+    fn from_error_kind(_input: &I, kind: ErrorKind) -> Self {
+        Self {
+            kind,
+            context: Vec::new(),
+            source: None,
+        }
+    }
+
+    fn append(self, _input: &I, kind: ErrorKind) -> Self {
+        Self {
+            kind,
+            context: Vec::new(),
+            source: Some(Box::new(self)),
+        }
+    }
+}
+
+impl<C, I> AddContext<I, C> for Error
+where
+    C: Into<Cow<'static, str>>,
+{
+    fn add_context(mut self, _input: &I, ctx: C) -> Self {
+        self.context.push(ctx.into());
+        self
+    }
+}
+
+impl<I, E: error::Error + Send + Sync + 'static> FromExternalError<I, E> for Error {
+    #[inline]
+    fn from_external_error(_input: &I, kind: ErrorKind, e: E) -> Self {
+        Self {
+            kind,
+            context: Vec::new(),
+            source: Some(Box::new(e)),
+        }
+    }
+}


### PR DESCRIPTION
`parse_tar` now break the iteration once it encounters `None` from `parse_entry` instead of using `Iterator::flatten`, which keeps going instead of breaking the loop.

It also fixed `parse_entry_streaming` to treat eof as end of the archive file as per the spec.

## Why rewrite using `winnow`?

 - [Clearer usage](https://epage.github.io/blog/2023/02/winnow-toml-edit-combine-nom/#usage)
 - [Simpler, Easier API](https://epage.github.io/blog/2023/02/winnow-toml-edit-combine-nom/#simple)
 - [Easier Debugging](https://epage.github.io/blog/2023/02/winnow-toml-edit-combine-nom/#debug)
 - [`Located` and `Stateful`](https://epage.github.io/blog/2023/02/winnow-toml-edit-combine-nom/#stream)
 - [Better performance](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/#numbers)
 - We will be able to switch to support any [`Stream`](https://docs.rs/winnow/latest/winnow/stream/trait.Stream.html) and any incomplete stream via [`StreamPartial`](https://docs.rs/winnow/latest/winnow/stream/trait.StreamIsPartial.html) simply by using generics

Related blog post:
 - [winnow = toml_edit + combine + nom](https://epage.github.io/blog/2023/02/winnow-toml-edit-combine-nom/)
 - [Winnow 0.5: The Fastest Rust Parser-Combinator Library?](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/)